### PR TITLE
Proposed bug fix to grid.js

### DIFF
--- a/grid.js
+++ b/grid.js
@@ -1354,7 +1354,7 @@ var grids = [];
 				$grid = $(grid.el),
 				nRows = grid.totalRows,
 				showing = grid.opts.nRowsShowing,
-				nPages = ~~(nRows / showing),
+				nPages = Math.ceil(nRows / showing),
 				page = parseInt(grid.opts.page),
 				$pager = null;
 			
@@ -1388,7 +1388,7 @@ var grids = [];
 				// setup slider
 				var nRows = this.grid.totalRows,
 					showing = this.grid.opts.nRowsShowing,
-					nPages = ~~(nRows / showing);
+					nPages = Math.ceil(nRows / showing);
 					
 				this.slider = Slider.inherit({
 					pager : this,


### PR DESCRIPTION
I had a problem with not being allowed to see the last page of rows. I had 14 total rows, showing 10 per page. When doing the math, you get 1.4 and I suppose the original code was saying that was one page. I added the javascript Math.ceil function to round up to 2 pages and it solved my problem.
