### PR TITLE
Change background-image URL

### DIFF
--- a/grid.css
+++ b/grid.css
@@ -357,7 +357,7 @@ div.gridWrapper .gridPager .search input:focus:after {
   position: absolute;
   top: 10px;
   left: -27px;
-  background-image: url("http://twitter.github.com/bootstrap/assets/img/glyphicons-halflings.png");
+  background-image: url("bootstrap/img/glyphicons-halflings.png");
   background-position: -48px 0px;
 }
 div.gridWrapper select {


### PR DESCRIPTION
glyphicons-halflings.png is already available inside the bootstrap folder & also, the link to http://twitter.github.com/bootstrap/assets/img/glyphicons-halflings.png is dead! I guess you forgot to update the URL.
